### PR TITLE
feat: add presentation decks used in SP1 edition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pdf filter=lfs diff=lfs merge=lfs -text

--- a/slides/BR-SP-23062022/AWS_LATAM_Containers_Roadshow-Amazon_EKS_Deep_Dive.pdf
+++ b/slides/BR-SP-23062022/AWS_LATAM_Containers_Roadshow-Amazon_EKS_Deep_Dive.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8018b3432dd7edebb6af0b5e44ec9329aa7b82386600f52c581eeab09fff2300
+size 7488469

--- a/slides/BR-SP-23062022/AWS_LATAM_Containers_Roadshow-Intro_to_Amazon_ECS.pdf
+++ b/slides/BR-SP-23062022/AWS_LATAM_Containers_Roadshow-Intro_to_Amazon_ECS.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7469a176fe98ce450900888e98d7bd6967831971e0e54e8a77fa9d640cfe44b5
+size 7158788

--- a/slides/BR-SP-23062022/AWS_LATAM_Containers_Roadshow-Introduction_to_ROSA.pdf
+++ b/slides/BR-SP-23062022/AWS_LATAM_Containers_Roadshow-Introduction_to_ROSA.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27defd8c81f73a9a31a787f849689bfbaa511387e305ec7046386f7b6f22dc46
+size 4153988

--- a/slides/BR-SP-23062022/AWS_LATAM_Containers_Roadshow-Opening_Session.pdf
+++ b/slides/BR-SP-23062022/AWS_LATAM_Containers_Roadshow-Opening_Session.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f69c688ad83d33c2f73ccba9a853a0747c39fd01529341a2cb2dd40c62d9148
+size 9785294


### PR DESCRIPTION
*Description of changes:*

This PR adds the presentations used during the São Paulo edition of LATAM Containers Roadshow. In order to properly store the large PDF files within the Git repository, this PR also enables LFS extension.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
