### PR TITLE
fix: replace pptx artefact with pdf

### DIFF
--- a/slides/BR-SP-23062022/AWS_LATAM_Containers_Roadshow-Cost_Optimization_with_Flexible_Compute.pdf
+++ b/slides/BR-SP-23062022/AWS_LATAM_Containers_Roadshow-Cost_Optimization_with_Flexible_Compute.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e79ad42a92e90dfde33ae98b9f47559b704a999d082c689f7cfc0e7d19bfc40
+size 11292886


### PR DESCRIPTION
*Description of changes:*

This is a minor fix to replace the slide using `pptx` format with `pdf` for consistency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
