### PR TITLE
Update Lambda runtime to Python 3.9

### DIFF
--- a/helpers/cloudformation-cloud9-template.yaml
+++ b/helpers/cloudformation-cloud9-template.yaml
@@ -177,7 +177,7 @@ Resources:
         Fn::GetAtt:
         - C9LambdaExecutionRole
         - Arn
-      Runtime: python3.6
+      Runtime: python3.9
       MemorySize: 256
       Timeout: 600
       Code:


### PR DESCRIPTION
*Issue #, if available:*

Fix #10 

*Description of changes:* 

Updates the AWS Lambda runtime from Python 3.6 to 3.9.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
