### PR TITLE
Update EKS Blueprint release to work with Terraform 1.3

### DIFF
--- a/workshops/eks/terraform/main.tf
+++ b/workshops/eks/terraform/main.tf
@@ -47,7 +47,7 @@ locals {
 # EKS Blueprints
 #---------------------------------------------------------------
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.0.7"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.16.0"
 
   cluster_name    = local.name
   cluster_version = "1.21"
@@ -86,7 +86,7 @@ module "eks_blueprints" {
 }
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.0.7"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.16.0"
 
   eks_cluster_id = module.eks_blueprints.eks_cluster_id
 


### PR DESCRIPTION
*Description of changes:*

Updates the EKS Blueprint released used in the workshop to fix the compatibility issue with Terraform 1.3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
